### PR TITLE
Remove explicit SSH forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,5 +17,4 @@ Vagrant::Config.run do |config|
 
   config.vm.forward_port 80,5080
   config.vm.forward_port 443,5443
-  config.vm.forward_port 22,5022
 end


### PR DESCRIPTION
Vagrant forwards SSH via its own mechanisms, so it's not useful to explicitly forward them in the Vagrantfile.
